### PR TITLE
Fix UIRenderer memory leak.

### DIFF
--- a/framework/PVRUtils/Vulkan/UIRendererVk.h
+++ b/framework/PVRUtils/Vulkan/UIRendererVk.h
@@ -275,6 +275,7 @@ public:
 		_uboMaterialLayout.reset();
 		_pipelineLayout.reset();
 		_pipeline.reset();
+		_pipelineCache.reset();
 		_samplerBilinear.reset();
 		_samplerTrilinear.reset();
 		_activeCommandBuffer.reset();


### PR DESCRIPTION
The pipeline cache object allocated by the UIRenderer to create
the sprite rendering pipeline is not deallocated in the
destroy function. This causes the Vulkan validation layers to
output a message and terminate the application with an exception
when running in debug mode.