### PR TITLE
Disable sampleShadingEnable for VulkanHelloAPI

### DIFF
--- a/examples/Vulkan/01_HelloAPI/VulkanHelloAPI.cpp
+++ b/examples/Vulkan/01_HelloAPI/VulkanHelloAPI.cpp
@@ -1407,7 +1407,7 @@ void VulkanHelloAPI::initPipeline()
 	multisamplingInfo.flags = 0;
 	multisamplingInfo.pSampleMask = nullptr;
 	multisamplingInfo.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-	multisamplingInfo.sampleShadingEnable = VK_TRUE;
+	multisamplingInfo.sampleShadingEnable = VK_FALSE;
 	multisamplingInfo.alphaToCoverageEnable = VK_FALSE;
 	multisamplingInfo.alphaToOneEnable = VK_FALSE;
 	multisamplingInfo.minSampleShading = 0.0f;


### PR DESCRIPTION
The Vulkan specification states that "If [the sampleRateShading feature]
is not enabled, the sampleShadingEnable member of the
VkPipelineMultisampleStateCreateInfo structure must be set to VK_FALSE".

Since this app doesn't use sample rate shading, this can be disabled so
that it can run on Vulkan drivers that don't support this feature.