### PR TITLE
Disable mipmapping for default bilinear sampler

### DIFF
--- a/framework/PVRUtils/OpenGLES/UIRendererGles.cpp
+++ b/framework/PVRUtils/OpenGLES/UIRendererGles.cpp
@@ -596,7 +596,7 @@ void UIRenderer::init_CreateDefaultSampler()
 		gl::GenSamplers(1, &_samplerBilinear);
 		gl::GenSamplers(1, &_samplerTrilinear);
 		debugThrowOnApiError("UIRenderer::init_CreateDefaultSampler 1.1");
-		gl::SamplerParameteri(_samplerBilinear, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_NEAREST);
+		gl::SamplerParameteri(_samplerBilinear, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		debugThrowOnApiError("UIRenderer::init_CreateDefaultSampler 1.2");
 		gl::SamplerParameteri(_samplerBilinear, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		debugThrowOnApiError("UIRenderer::init_CreateDefaultSampler 1.3");


### PR DESCRIPTION
Textures used for text rendering are created without mipmaps, but the
sampler is configured to perform nearest mipmap filtering. This makes
the texture incomplete:

OpenGL ES 3.2 section 8.17.1: "if the texture is not mipmap complete and
the sampler object specifies a TEXTURE_MIN_FILTER requiring mipmaps, the
texture will be considered incomplete for the purposes of that texture
unit"

This fixes text rendering with ANGLE.