### PR TITLE
Fix Linux GCC 11.1 build.

### DIFF
--- a/examples/Vulkan/01_HelloAPI/VulkanHelloAPI.h
+++ b/examples/Vulkan/01_HelloAPI/VulkanHelloAPI.h
@@ -9,6 +9,7 @@
 #include "vk_getProcAddrs.h"
 #include <string>
 #include <array>
+#include <limits>
 
 #include <sstream>
 #include <iostream>


### PR DESCRIPTION
As in title + change mode of binary glslangValidator to executable.