### PR TITLE
Fix xdg_surface has never been configured

### DIFF
--- a/examples/Vulkan/01_HelloAPI/MainLinuxWayland.cpp
+++ b/examples/Vulkan/01_HelloAPI/MainLinuxWayland.cpp
@@ -153,6 +153,7 @@ void createWaylandWindowSurface(VulkanHelloAPI& vulkanExample)
 	xdg_toplevel_add_listener(vulkanExample.surfaceData.xdgToplevel, &xdgToplevelListener, &vulkanExample.surfaceData);
 	xdg_toplevel_set_title(vulkanExample.surfaceData.xdgToplevel, "HelloApiVk");
 	xdg_toplevel_set_app_id(vulkanExample.surfaceData.xdgToplevel, "OpenGLESHelloAPI");
+	wl_surface_commit(vulkanExample.surfaceData.surface);
 }
 
 void releaseWaylandConnection(VulkanHelloAPI& vulkanExample)


### PR DESCRIPTION
On my target 01_HelloAPI Vulkan example is giving this error:
xdg_surface@7: error 3: xdg_surface has never been configured

wl_surface_commit is needed to configure xdg_surface. This call is present in PVRShell (framework/PVRShell/OS/Linux/Wayland/ShellOS.cpp line 376) but not in 01_HelloAPI Wayland implementation.