### PR TITLE
Fix wrong path for finding cmake packages in GLES HelloAPI example

### DIFF
--- a/examples/OpenGLES/01_HelloAPI/CMakeLists.txt
+++ b/examples/OpenGLES/01_HelloAPI/CMakeLists.txt
@@ -3,7 +3,7 @@ project(OpenGLESHelloAPI)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(SDK_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../..)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${SDK_ROOT}/framework/cmake/modules")  #for find_package
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${SDK_ROOT}/cmake/modules")  #for find_package
 
 if(NOT CMAKE_BUILD_TYPE) #Default to release if the user passes nothing.
 	set(CMAKE_BUILD_TYPE "Release")


### PR DESCRIPTION
Path to cmake packages seems wrong:
set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${SDK_ROOT}/framework/cmake/modules")  #for find_package
In framework folder there is no sub folder cmake

Correct path should be
set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${SDK_ROOT}/cmake/modules")  #for find_package

Like it is already done in Vulkan 01_HelloAPI example:
https://github.com/powervr-graphics/Native_SDK/blob/master/examples/Vulkan/01_HelloAPI/CMakeLists.txt
